### PR TITLE
Fix Vagga build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: generic
-dist: xenial
+dist: trusty
 sudo: required
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - vagga _build mysql-trunk
   - vagga _build static-trunk
   - vagga _build elastic-trunk
-  - vagga _build logs-trunk
+  # FIXME: - vagga _build logs-trunk
 
 deploy:
   - provider: script
@@ -38,7 +38,7 @@ deploy:
       --project tabun
       --type trunk
       --blobs "static"
-      --containers "redis celery php mysql elastic logs"
+      --containers "redis celery php mysql elastic"
       --destination $deploy_destination
       --server $deploy_host
       --port $deploy_port

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - .vagga/.cache
 
 install:
-  - "echo nameserver 1.1.1.1 | sudo tee /etc/resolv.conf"
   - "echo ubuntu-mirror: http://us.archive.ubuntu.com/ubuntu/ > ~/.vagga.yaml"
   - "echo alpine-mirror: http://mirrors.gigenet.com/alpinelinux/ >> ~/.vagga.yaml"
   - "echo travis:100000:65536 | sudo tee /etc/subuid | sudo tee /etc/subgid"

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -160,6 +160,8 @@ containers:
     - !Sh python3 -m compileall /app
     - !*Unpack
       - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -174,6 +176,8 @@ containers:
     - !Sh python3 -m compileall /app
     - !*Unpack
       - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -194,6 +198,8 @@ containers:
     - !*Unpack
       - *trunk_stuff
       - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -203,6 +209,8 @@ containers:
     - !*Unpack
       - *production_stuff
       - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -244,6 +252,8 @@ containers:
       path: /etc/mysql
     - !*Unpack
       - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -257,6 +267,8 @@ containers:
       path: /etc/mysql
     - !*Unpack
       - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -341,6 +353,8 @@ containers:
         path: /app/frontend.version
       - !*Unpack
         - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -379,6 +393,8 @@ containers:
         path: /app/frontend.version
       - !*Unpack
         - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -417,6 +433,8 @@ containers:
         path: /etc/elasticsearch
       - !*Unpack
         - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -430,6 +448,8 @@ containers:
         path: /etc/elasticsearch
       - !*Unpack
         - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -450,6 +470,8 @@ containers:
         path: /opt/.log.io
       - !*Unpack
         - *host_resolution
+    volumes:
+      /state: !Tmpfs
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -154,11 +154,12 @@ containers:
     - !Container celery
     - !*Unpack
       - *trunk_stuff
-      - *host_resolution
     - !Copy
       source: /work/celery_tasks
       path: /app
     - !Sh python3 -m compileall /app
+    - !*Unpack
+      - *host_resolution
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -167,11 +168,12 @@ containers:
     - !Container celery
     - !*Unpack
       - *production_stuff
-      - *host_resolution
     - !Copy
       source: /work/celery_tasks
       path: /app
     - !Sh python3 -m compileall /app
+    - !*Unpack
+      - *host_resolution
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -237,10 +239,11 @@ containers:
     - !Container mysql-dev
     - !*Unpack
       - *trunk_stuff
-      - *host_resolution
     - !Copy
       source: /config/mysql
       path: /etc/mysql
+    - !*Unpack
+      - *host_resolution
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -249,10 +252,11 @@ containers:
     - !Container mysql-dev
     - !*Unpack
       - *production_stuff
-      - *host_resolution
     - !Copy
       source: /config/mysql
       path: /etc/mysql
+    - !*Unpack
+      - *host_resolution
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -308,7 +312,6 @@ containers:
       - !Container _php-base
       - !*Unpack
         - *trunk_stuff
-        - *host_resolution
       - !Copy
         source: /config/php
         path: /etc/php/5.6/fpm
@@ -336,6 +339,8 @@ containers:
       - !Copy
         source: /mnt/frontend.version
         path: /app/frontend.version
+      - !*Unpack
+        - *host_resolution
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -345,7 +350,6 @@ containers:
       - !Install [php5.6-xcache]
       - !*Unpack
         - *production_stuff
-        - *host_resolution
       - !Copy
         source: /config/php
         path: /etc/php/5.6/fpm
@@ -373,6 +377,8 @@ containers:
       - !Copy
         source: /mnt/frontend.version
         path: /app/frontend.version
+      - !*Unpack
+        - *host_resolution
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -406,10 +412,11 @@ containers:
       - !Container elastic-dev
       - !*Unpack
         - *trunk_stuff
-        - *host_resolution
       - !Copy
         source: /config/elasticsearch
         path: /etc/elasticsearch
+      - !*Unpack
+        - *host_resolution
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -418,10 +425,11 @@ containers:
       - !Container elastic-dev
       - !*Unpack
         - *production_stuff
-        - *host_resolution
       - !Copy
         source: /config/elasticsearch
         path: /etc/elasticsearch
+      - !*Unpack
+        - *host_resolution
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 
@@ -437,10 +445,11 @@ containers:
         - log.io
       - !*Unpack
         - *trunk_stuff
-        - *host_resolution
       - !Copy
         source: /config/.log.io
         path: /opt/.log.io
+      - !*Unpack
+        - *host_resolution
     resolv-conf-path: /state/resolv.conf
     hosts-file-path: /state/hosts
 


### PR DESCRIPTION
Для тех, кто не понимает, что происходит.

`/etc/hosts` и `/etc/resolv.conf` хардкодить в контейнерах нежелательно, поэтому [lithos автоматически помещает эти файлы](https://lithos.readthedocs.io/en/latest/tips/vagga.html) в отдельно монтируемый каталог `/state`, а в контейнере нужно прописать симлинки на эти файлы. Этим занимается сниппет `host_resolution` в `vagga.yaml`.

Прикол в том, что в момент сборки контейнеров помещать файлы в каталог `/state` некому: lithos ещё не работает, а сама vagga будет учитывать опции `resolv-conf-path` и `hosts-file-path` и монтировать эти файлы только после сборки, во время запуска контейнеров.

Этот `host_resolution` почему-то стоял в начале `setup`'ов. В итоге получается, что во время установки `/etc/resolv.conf` ссылается на несуществующий `/state/resolv.conf`, и все последующие команды установки, взаимодействующие с интернетом, обламывались на DNS, например, apt не мог скачать пакет из-за `Temporary failure resolving 'us.archive.ubuntu.com'`.

Контейнеры, в которых `host_resolution` не был прописан (например, `redis` или `_php-base`), имели дефолтный resolv.conf, который vagga копировала с хоста автоматически, и поэтому собирались нормально. По такой же случайности работали [билды ponyFiction](https://travis-ci.org/everypony/ponyFiction/builds/204097334): контейнеры с `host_resolution` не использовали интернет и успешно собирались.

Перемещение `host_resolution` в конец `setup`а исправляет проблему со сборкой контейнеров, потому что на время работы `setup`'а файл resolv.conf ещё существующий и вполне рабочий. Но в конце нужно заменить его на симлинк для запуска в lithos.

Так как опции `resolv-conf-path` и `hosts-file-path` работают только во время запуска контейнеров уже после сборки, а trunk и prod контейнеры только собираются, но никогда не запускается ваггой (их запускает lithos), то эти опции вместе с `volumes: /state: !Tmpfs` оказались по сути декоративными и ничего не делающими. Но есть мнение, что пусть будут для консистентности

---

А ещё log.io просто протух и не дружит с новым nodejs, а в xenial кто-то блокирует dpkg, возможно unattended-upgrades (но я не исследовал проблему с dpkg lock детально)