### PR TITLE
Изменение для Font Awesome

### DIFF
--- a/frontend/main.styl
+++ b/frontend/main.styl
@@ -25,7 +25,6 @@
 @require './styles/dice.styl'
 @require './styles/login.css'
 @require './styles/adaptive.styl'
-@require '../node_modules/@fortawesome/fontawesome-free/css/all.css'
 
 // From components
 @require './styles/fileinput.styl'

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "react": "~15.3",
     "react-avatar-editor": "8.0.1",
     "react-dom": "~15.3",
-    "xhr": "^2.5.0",
-    "@fortawesome/fontawesome-free": "^5.5.0"
+    "xhr": "^2.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "~15.3",
     "react-avatar-editor": "8.0.1",
     "react-dom": "~15.3",
-    "xhr": "^2.5.0"
+    "xhr": "^2.5.0",
+    "@fortawesome/fontawesome-free": "^5.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.5",

--- a/templates/skin/synio/header.tpl
+++ b/templates/skin/synio/header.tpl
@@ -14,7 +14,6 @@
     <meta name="keywords" content="{$sHtmlKeywords}">
 
     <link rel="stylesheet" type="text/css" href="{cfg name='path.static.url'}/main.{cfg name='misc.ver.front'}.css">
-    <link rel="stylesheet" type="text/css" href="{cfg name='path.static.url'}/vendor.{cfg name='misc.ver.front'}.css">
     {if isset($styles)}
         {foreach from=$styles item=item}
             <link rel="stylesheet" type="text/css" href="{cfg name='path.static.url'}/{$item}.{cfg name='misc.ver.front'}.css">


### PR DESCRIPTION
Я проверил mask и FA на Opera 12.18 в Windows XP - ни `mask`, ни `-webkit-mask`, ни `mask-image` не работают, вместо иконок серые квадратики.
Вот только иконки FA также не работают нормально.
<details>
<summary>Спойлер</summary>

![https://cdn.everypony.ru/storage/01/67/83/2018/12/17/fb04d5261a.png](https://cdn.everypony.ru/storage/01/67/83/2018/12/17/fb04d5261a.png)
</details>
По какой-то причине из всех нужных работали только иконки edit и lock, т.е. иконки 4-й версии FA.

А это нарушение информативности.
<details>
<summary>Поэтому...</summary>

![https://cdn.everypony.ru/storage/01/67/83/2018/12/17/4f62c6c188.jpg](https://cdn.everypony.ru/storage/01/67/83/2018/12/17/4f62c6c188.jpg)
</details>
(Также там есть и другие артефакты - например, страница мгновенно прокручивается вверх при наведении мышки на какие-то элементы. Впрочем, я и не удивляюсь, ведь ещё в далёком 2014 в Опере 12 нормально не работал Табун и поэтому мне пришлось пересесть на другой браузер.)
<br><br>

В Opera 15.0.1147.138 в Windows XP mask уже работает (но какое именно свойством CSS - не знаю, не выяснял). Но шрифты FA до сих пор не работают нормально.
<details>
<summary>Спойлер</summary>

![https://cdn.everypony.ru/storage/01/67/83/2018/12/17/c516e64747.png](https://cdn.everypony.ru/storage/01/67/83/2018/12/17/c516e64747.png)
</details>
(Правда, с остальным там тоже не всё OK: https://cdn.everypony.ru/storage/01/67/83/2018/12/17/3878a3369b.png)
<br><br>
Из этого следует, что эти веб-шрифты не так уж хорошо поддерживаются браузерами, как хотелось бы. А ведь это имело значение.
<br><br>
Так что я в своих изменениях для Issue #150 возвращаюсь на SVG. А нужны ли шрифты FA в другом месте Табуна и на текущем этапе разработки? Ну, если кто-нибудь решит перевести на FA другие иконки, а использовать SVG не захочет - может быть, в таком случае FA можно и не убирать.