### PR TITLE
Аватарки и фото на стороне сервере | Перепись с GD на ImageMagick

### DIFF
--- a/engine/lib/external/LiveImage/Image.php
+++ b/engine/lib/external/LiveImage/Image.php
@@ -117,6 +117,13 @@ class LiveImage {
 	 */
 	public function __construct($sFile) {
         $this->magic = new Imagick();
+		try {
+			$this->magic->readImage($sFile);
+		} catch (Exception $e) {
+			$this->set_last_error(4);
+			return false;
+		}
+		
         $this->fileInfo = finfo_open(FILEINFO_MIME_TYPE);
 
 		if(!$sFile) {
@@ -124,7 +131,6 @@ class LiveImage {
 			return false;
 		}
 
-        $this->magic->readImage($sFile);
         $sMime = finfo_file($this->fileInfo, $sFile);
 
         $iFileLength = (int) $this->magic->getImageLength();
@@ -152,13 +158,6 @@ class LiveImage {
 				$this->set_last_error(5);				
 				return false;
 		}		
-		/**
-		 * Если изображение не удалось создать
-		 */
-		if(!$this->magic){
-			$this->set_last_error(4);
-			return false;
-		}
 
 		$this->image=$this->magic;
 		$this->width=(int)$this->magic->getImageWidth();


### PR DESCRIPTION
Файл `./engine/lib/external/LiveImage/Image.php` был переписан на ImageMagick за исключением неиспользующихся в коде функций (закомментированы)

В файле `./classes/actions/ActionSettings.class.php`:
* Функции `EventUploadFoto` и `EventResizeFoto` сокращены до одной `EventUploadFoto`
* Функции `EventUploadAvatar` и `EventResizeAvatar` сокращены до одной `EventUploadAvatar`

Исправление для https://github.com/everypony/tabun/issues/115