### PR TITLE
Docker: том `storage`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.7'
 volumes:
   static:
   elastic:
+  storage:
 
 services:
   php-fpm:
@@ -17,6 +18,7 @@ services:
       - .:/app
       - /app/vendor
       - static:/static
+      - storage:/storage
     depends_on:
       - mariadb
 
@@ -41,6 +43,7 @@ services:
     volumes:
       - .:/app
       - static:/app/static
+      - storage:/storage
     depends_on:
       - php-fpm
 

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -5,4 +5,9 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 COPY docker/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# FIXME: Придумать что-то более красивое, чем это
+RUN sed -ri 's/^nginx:x:101:101:/nginx:x:33:33:/' /etc/passwd
+RUN mkdir -p /storage
+RUN chown -R nginx:nginx /storage
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -37,6 +37,11 @@ COPY ./docker/php/www-dev.conf /usr/local/etc/php-fpm.d/www.conf
 COPY composer.* ./
 RUN composer install
 
+# FIXME: Придумать что-то более красивое, чем это
+RUN sed -ri 's/^www-data:x:82:82:/www-data:x:1000:50:/' /etc/passwd
+RUN mkdir -p /storage
+RUN chown -R www-data:www-data /storage
+
 CMD ["php-fpm"]
 
 


### PR DESCRIPTION
В прошлом пулл-реквесте (https://github.com/everypony/tabun/pull/170) было сделано всё, кроме `/storage`. Главной проблемой являются права доступа. Пока что не придумал ничего лучше этого костыля. Может кто придумает вариант получше?
Оно работает, просто решение мне не нравится.
![unknown](https://user-images.githubusercontent.com/26777464/143299125-861fc72e-93e5-4ca2-8a5c-de1520ada062.png)
